### PR TITLE
Correcting 'cannot convert null to object' exception in flatten function

### DIFF
--- a/src/util.test.ts
+++ b/src/util.test.ts
@@ -1,0 +1,37 @@
+import {flatten} from './util.ts'
+
+test('flatten function test', () => {
+  
+	let obj = {
+		"string":"hello",
+		"number":123,
+		"float":123.4,
+		"null":null,
+		"undefined":undefined,
+		"array":[1,2,3],
+		"nested": {
+			"string":"hello",
+			"number":123,
+			"float":123.4,
+			"null":null,
+			"undefined":undefined,
+		}	
+	}
+
+	let flattenObj = {
+		"string":"hello",
+		"number":123,
+		"float":123.4,
+		"null":null,
+		"undefined":undefined,
+		"array":[1,2,3],
+		"nested.string":"hello",
+		"nested.number":123,
+		"nested.float":123.4,
+		"nested.null":null,
+		"nested.undefined":undefined,
+	}
+
+
+	expect(flatten(obj)).toMatchObject(flattenObj);
+});

--- a/src/util.test.ts
+++ b/src/util.test.ts
@@ -24,7 +24,9 @@ test('flatten function test', () => {
 		"float":123.4,
 		"null":null,
 		"undefined":undefined,
-		"array":[1,2,3],
+		"array.0":1,
+		"array.1":2,
+		"array.2":3,
 		"nested.string":"hello",
 		"nested.number":123,
 		"nested.float":123.4,
@@ -32,6 +34,5 @@ test('flatten function test', () => {
 		"nested.undefined":undefined,
 	}
 
-
-	expect(flatten(obj)).toMatchObject(flattenObj);
+	expect(flatten(obj)).toEqual(flattenObj);
 });

--- a/src/util.ts
+++ b/src/util.ts
@@ -1,6 +1,9 @@
+
+
 export function flatten<T extends Record<string, any>>(object: T, path: string | null = null, separator = '.'): T {
   return Object.keys(object).reduce((acc: T, key: string): T => {
+  	const isObject = typeof(object[key]) === 'object' && object[key] != null && !Array.isArray(object[key]);
     const newPath = [path, key].filter(Boolean).join(separator);
-    return typeof object[key] === 'object' ? { ...acc, ...flatten(object[key], newPath, separator) } : { ...acc, [newPath]: object[key] };
+    return isObject ? { ...acc, ...flatten(object[key], newPath, separator) } : { ...acc, [newPath]: object[key] };
   }, {} as T);
 }

--- a/src/util.ts
+++ b/src/util.ts
@@ -2,7 +2,7 @@
 
 export function flatten<T extends Record<string, any>>(object: T, path: string | null = null, separator = '.'): T {
   return Object.keys(object).reduce((acc: T, key: string): T => {
-  	const isObject = typeof(object[key]) === 'object' && object[key] != null && !Array.isArray(object[key]);
+  	const isObject = typeof(object[key]) === 'object' && object[key] != null;
     const newPath = [path, key].filter(Boolean).join(separator);
     return isObject ? { ...acc, ...flatten(object[key], newPath, separator) } : { ...acc, [newPath]: object[key] };
   }, {} as T);


### PR DESCRIPTION
The `flatten` function was called on no-objects causing the `Object.keys(object)` to throw `Cannot convert null to object` exception. This is because `typeof(something) === 'object'` is true not only for objects, but also for `null` and Arrays. Therefore `flatten` was recursively called for `null` values and Arrays, whenever one of those is present in the query response.

Testing properly those cases allows to only recursively call `flatten` on actual objects.