### PR TITLE
Fix error in isRFC3339_ISO6801

### DIFF
--- a/src/util.ts
+++ b/src/util.ts
@@ -9,6 +9,9 @@ export function flatten<T extends Record<string, any>>(object: T, path: string |
 }
 
 export function isRFC3339_ISO6801(str: any): boolean {
+  if (typeof str !== 'string') {
+    return false;
+  }
   let date = dateTime(str, ISO_8601);
   if (date.isValid()) {
     let iso = date.toISOString();


### PR DESCRIPTION
Fixes `TypeError: str.substring is not a function` when large integers are returned from queries.